### PR TITLE
Add Docker Compose setup for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ Atendechat é uma plataforma omnichannel para atendimento via WhatsApp que reún
 ## Automação completa (opcional)
 Para implantações completas em servidores Linux, utilize os scripts do diretório `home/atendechat-instalador`. O script `install_primaria` provê instalação primária (dependências do sistema, clone do repositório, build e configuração de nginx/certbot). Consulte os scripts e adapte variáveis em `home/atendechat-instalador/variables` conforme o ambiente alvo.
 
+## Executando com Docker
+Uma alternativa ao setup manual é utilizar os arquivos de contêiner incluídos neste repositório. Eles provisionam PostgreSQL, Redis, o backend Node.js e o frontend React prontos para uso local.
+
+1. Copie (ou ajuste) os valores padrão das variáveis no arquivo `docker-compose.yml` caso deseje customizar segredos ou apontar para serviços externos.
+2. Construa as imagens e inicialize os serviços:
+   ```bash
+   docker compose up --build
+   ```
+3. A aplicação ficará disponível em:
+   - Frontend: http://localhost:3000
+   - Backend/API: http://localhost:8080
+
+O volume nomeado `backend_public` preserva os arquivos enviados pelo backend, enquanto `postgres_data` e `redis_data` retêm dados do banco e cache. Para redefinir o ambiente, remova esses volumes com `docker compose down -v`.
+
 ## Estrutura do repositório
 ```
 ├── README.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,89 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:14-alpine
+    container_name: atendechat-postgres
+    environment:
+      POSTGRES_DB: atendechat
+      POSTGRES_USER: atendechat
+      POSTGRES_PASSWORD: atendechat
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U atendechat"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: atendechat-redis
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  backend:
+    build:
+      context: ./home/deploy/mandivia/backend
+      dockerfile: Dockerfile
+    container_name: atendechat-backend
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      PORT: 8080
+      BACKEND_URL: http://localhost:8080
+      FRONTEND_URL: http://localhost:3000
+      PROXY_PORT: 8080
+      DB_DIALECT: postgres
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USER: atendechat
+      DB_PASS: atendechat
+      DB_NAME: atendechat
+      JWT_SECRET: kZaOTd+YZpjRUyyuQUpigJaEMk4vcW4YOymKPZX0Ts8=
+      JWT_REFRESH_SECRET: dBSXqFg9TaNUEDXVp6fhMTRLBysP+j2DSqf7+raxD3A=
+      REDIS_URI: redis://redis:6379
+      REDIS_OPT_LIMITER_MAX: 1
+      REDIS_OPT_LIMITER_DURATION: 3000
+      USER_LIMIT: 10000
+      CONNECTIONS_LIMIT: 100000
+      CLOSED_SEND_BY_ME: "true"
+      GERENCIANET_SANDBOX: "false"
+      GERENCIANET_CLIENT_ID: Client_Id_Gerencianet
+      GERENCIANET_CLIENT_SECRET: Client_Secret_Gerencianet
+      GERENCIANET_PIX_CERT: certificado-Gerencianet
+      GERENCIANET_PIX_KEY: chave-pix-gerencianet
+    ports:
+      - "8080:8080"
+    volumes:
+      - backend_public:/app/public
+      - ./home/deploy/mandivia/backend/certs:/app/certs:ro
+
+  frontend:
+    build:
+      context: ./home/deploy/mandivia/frontend
+      dockerfile: Dockerfile
+      args:
+        REACT_APP_BACKEND_URL: http://localhost:8080
+        REACT_APP_HOURS_CLOSE_TICKETS_AUTO: 24
+    container_name: atendechat-frontend
+    depends_on:
+      backend:
+        condition: service_started
+    ports:
+      - "3000:80"
+
+volumes:
+  postgres_data:
+  redis_data:
+  backend_public:

--- a/home/deploy/mandivia/backend/.dockerignore
+++ b/home/deploy/mandivia/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+dist
+.env

--- a/home/deploy/mandivia/backend/Dockerfile
+++ b/home/deploy/mandivia/backend/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.4
+
+FROM node:18-slim AS builder
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 \
+    NPM_CONFIG_FUND=false \
+    NPM_CONFIG_AUDIT=false
+
+WORKDIR /app
+
+COPY package*.json ./
+COPY tsconfig.json ./
+RUN npm install
+
+COPY src ./src
+COPY certs ./certs
+
+RUN npm run build
+RUN npm prune --production
+
+FROM node:18-slim AS runner
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+# Install system dependencies required at runtime
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg tini \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/certs ./certs
+COPY .sequelizerc ./.sequelizerc
+
+EXPOSE 8080
+
+ENTRYPOINT ["tini", "--"]
+CMD ["sh", "-c", "npm run db:migrate && node dist/server.js"]

--- a/home/deploy/mandivia/frontend/.dockerignore
+++ b/home/deploy/mandivia/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+build
+npm-debug.log
+Dockerfile
+.dockerignore
+.env
+.env.*

--- a/home/deploy/mandivia/frontend/Dockerfile
+++ b/home/deploy/mandivia/frontend/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.4
+
+FROM node:18-slim AS builder
+
+ENV NPM_CONFIG_FUND=false \
+    NPM_CONFIG_AUDIT=false
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY public ./public
+COPY src ./src
+COPY .env.exemple ./.env.exemple
+
+ARG REACT_APP_BACKEND_URL=http://localhost:8080
+ARG REACT_APP_HOURS_CLOSE_TICKETS_AUTO=24
+ENV REACT_APP_BACKEND_URL=$REACT_APP_BACKEND_URL \
+    REACT_APP_HOURS_CLOSE_TICKETS_AUTO=$REACT_APP_HOURS_CLOSE_TICKETS_AUTO
+
+RUN printf "REACT_APP_BACKEND_URL=%s\nREACT_APP_HOURS_CLOSE_TICKETS_AUTO=%s\n" "$REACT_APP_BACKEND_URL" "$REACT_APP_HOURS_CLOSE_TICKETS_AUTO" > .env.production
+
+RUN npm run build
+
+FROM nginx:1.25-alpine AS runner
+
+COPY --from=builder /app/build /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add a docker-compose stack that provisions PostgreSQL, Redis, the backend API and the frontend
- create Dockerfiles for the backend and frontend images used by the compose stack
- document how to start the project with Docker in the README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e5b939d9c88330a2c948d01cf6d9e9