### PR TITLE
Install Chromium in backend Docker image for Puppeteer

### DIFF
--- a/home/deploy/mandivia/backend/Dockerfile
+++ b/home/deploy/mandivia/backend/Dockerfile
@@ -20,12 +20,13 @@ RUN npm prune --production
 
 FROM node:18-slim AS runner
 
-ENV NODE_ENV=production
+ENV NODE_ENV=production \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 WORKDIR /app
 
 # Install system dependencies required at runtime
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ffmpeg tini \
+  && apt-get install -y --no-install-recommends chromium ffmpeg tini \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/package*.json ./


### PR DESCRIPTION
## Summary
- install the Debian chromium package in the backend runtime Docker image
- configure PUPPETEER_EXECUTABLE_PATH so Puppeteer picks up the system Chromium binary

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e5be60f88c8330b01f3d553a0044ec