### PR TITLE
Fix Puppeteer Chromium availability in backend Docker image

### DIFF
--- a/home/deploy/mandivia/backend/Dockerfile
+++ b/home/deploy/mandivia/backend/Dockerfile
@@ -2,8 +2,7 @@
 
 FROM node:18-slim AS builder
 
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 \
-    NPM_CONFIG_FUND=false \
+ENV NPM_CONFIG_FUND=false \
     NPM_CONFIG_AUDIT=false
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- remove the PUPPETEER_SKIP_CHROMIUM_DOWNLOAD flag so Puppeteer downloads its bundled Chromium during the build

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e5bf30d7008330a3f17e2fe9063b7e